### PR TITLE
storage-fix

### DIFF
--- a/src/Components/MealCont.jsx
+++ b/src/Components/MealCont.jsx
@@ -4,12 +4,12 @@ import { getMealRecommendations } from "../Utils/mealsServics";
 import "../Styles/DashboardMeals.css";
 
 const MealCont = ({ num, type, cl, bkg }) => {
-  const { profile } = useAuth();
+  const { profile, user } = useAuth();
   const [meals, setMeals] = useState([]);
 
   useEffect(() => {
     if (profile) {
-      getMealRecommendations(profile).then(setMeals);
+      getMealRecommendations(profile, user.uid).then(setMeals);
     }
   }, [profile]);
   //Menu image------------------------------------------------------------------

--- a/src/Context/AuthContext.jsx
+++ b/src/Context/AuthContext.jsx
@@ -3,8 +3,8 @@ import { auth, db } from "../Components/firebase";
 import { onAuthStateChanged } from "firebase/auth";
 import { doc, getDoc } from "firebase/firestore";
 import { logUserLogin } from "../Utils/LogDates";
-const AuthContext = createContext();
 
+const AuthContext = createContext();
 export const AuthProvider = ({ children }) => {
   const [user, setUser] = useState(null);
   const [profile, setProfile] = useState(null);

--- a/src/Utils/LogDates.jsx
+++ b/src/Utils/LogDates.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { setDoc, doc, collection, getDocs } from "firebase/firestore";
 import { db } from "../Components/firebase";
 
@@ -6,7 +5,6 @@ import { db } from "../Components/firebase";
 export const logUserLogin = async (userId) => {
   const today = new Date().toISOString().split("T")[0];
   const ref = doc(db, "users", userId, "logins", today);
-
   await setDoc(ref, { loggedIn: true, timestamp: new Date() }, { merge: true });
 };
 

--- a/src/Utils/mealsServics.jsx
+++ b/src/Utils/mealsServics.jsx
@@ -1,9 +1,30 @@
-const API_KEY = import.meta.env.VITE_SPOONACULAR_KEY;
+import { collection, getDocs, query, where, addDoc } from "firebase/firestore";
+import { db } from "../Components/firebase";
 import calculateDailyCalories from "./DailyCalories";
 
-export async function getMealRecommendations(userProfile) {
+const API_KEY = import.meta.env.VITE_SPOONACULAR_KEY;
+
+export async function getMealRecommendations(userProfile, userId) {
+  const today = new Date().toISOString().split("T")[0]; //store today's date in YYYY-MM-DD format
   try {
-    // compute dailyCalories using utils function
+    // Reference that points to mealPlans collection in database "users" for
+    //the logged in user
+    const mealPlansRef = collection(db, "users", userId, "mealPlans");
+
+    // Query to look for meals stored in today's date
+    const q = query(mealPlansRef, where("date", "==", today));
+    //if there are any store them in querySnapshot
+    const querySnapshot = await getDocs(q);
+
+    // If querySnapshot is not empty, return it's meals
+    if (!querySnapshot.empty) {
+      const docData = querySnapshot.docs[0].data();
+      return docData.meals;
+    }
+    /*------------code below here only executes if there aren't any meals saved in today's date------------------- */
+
+    //if querySnapshot happens to be empty then calculate the daily calories needed
+    //by the logged-in user
     const targetCalories = calculateDailyCalories({
       weight: userProfile.weight,
       height: userProfile.height,
@@ -13,13 +34,21 @@ export async function getMealRecommendations(userProfile) {
       activityLevel: userProfile.activityLevel,
     });
 
+    // After calculations Fetch meals from Spoonacular API
     const url = `https://api.spoonacular.com/mealplanner/generate?timeFrame=day&targetCalories=${targetCalories}&apiKey=${API_KEY}`;
-
     const response = await fetch(url);
     if (!response.ok) throw new Error("Failed to fetch meals");
 
     const data = await response.json();
-    return data.meals;
+    const meals = data.meals;
+
+    // Store the meals where mealPlanRef points with today's date
+    await addDoc(mealPlansRef, {
+      date: today,
+      meals,
+    });
+
+    return meals;
   } catch (error) {
     console.error("Error fetching meal recommendations:", error);
     return [];


### PR DESCRIPTION
previously every single time the meal rendering page was refreshed the system would make a new meal fetch from the Api which resulted in two things:
1. Inconsistency of meal choice/recommendation
 2.Due to the number of fetches this would result in exceeding the daily quota the api allows for fetching meals.

to remedy this I implemented some changes:

1. create a reference "mealPlansRef" which points to subcollection "mealPLans" in database "users".
2. A query named "q" to look if in mealPlansRef there are any meals stored with today's date
3.should the query find any, we will store them in variable "querySnapshot"
4. if querySnapshot is not empty then return the meals stored in today's date.