### PR TITLE
dashboard-meals-scroll

### DIFF
--- a/src/Pages/Dashboard.jsx
+++ b/src/Pages/Dashboard.jsx
@@ -32,7 +32,6 @@ const Dashboard = () => {
         return <DashboardHome />;
     }
   };
-
   return (
     <>
       <PopUp />
@@ -77,10 +76,7 @@ const Dashboard = () => {
         </div>
         {/*DASHBOARD MAIN INFO--------------------------- */}
         <div className="dashInfo">
-          <section className="dashHome">
-            {/* <Settings /> */}
-            {renderContent()}
-          </section>
+          <section className="dashHome">{renderContent()}</section>
         </div>
       </section>
     </>

--- a/src/Styles/Dashboard.css
+++ b/src/Styles/Dashboard.css
@@ -1,6 +1,3 @@
-/* * {
-  outline: 1px solid black;
-} */
 .dashCont {
   min-width: 100%;
   min-height: 100vh;
@@ -77,7 +74,8 @@
 .dashHome {
   position: inherit;
   width: 100%;
-  height: 100vh;
+  height: 100%;
+  overflow-y: auto;
 }
 /*----------------------Scroller-----------------------*/
 /* ::-webkit-scrollbar {


### PR DESCRIPTION
in dashboard meals I had content overflowing vertically. because of the way i render my side bar navigations as components and not new pages overall. making the dashboard scrollable overall wasn't favorable because the scroll bar would appear even on pages that don't require scrolling.

these changes fix that problem